### PR TITLE
Get() method for accessing the current value

### DIFF
--- a/pb.go
+++ b/pb.go
@@ -125,6 +125,12 @@ func (pb *ProgressBar) Increment() int {
 	return pb.Add(1)
 }
 
+// Get current value
+func (pb *ProgressBar) Get() int64 {
+	c := atomic.LoadInt64(&pb.current)
+	return c
+}
+
 // Set current value
 func (pb *ProgressBar) Set(current int) *ProgressBar {
 	return pb.Set64(int64(current))


### PR DESCRIPTION
Created Get() method for accessing the current value of the progress bar. Part of fix for https://github.com/minio/mc/issues/1633. 